### PR TITLE
Prefix relative paths with '.'

### DIFF
--- a/plugin/ZFVimDirDiff.vim
+++ b/plugin/ZFVimDirDiff.vim
@@ -39,8 +39,10 @@ augroup ZF_DirDiff_augroup
 augroup END
 
 " function name to get the header text
-"     YourFunc(isLeft, fileLeft, fileRight)
+"     YourFunc()
 " return a list of string
+"   Use b:ZFDirDiff_isLeft, b:ZFDirDiff_fileLeft, b:ZFDirDiff_fileRight to
+"   build your header
 if !exists('g:ZFDirDiffUI_headerTextFunc')
     let g:ZFDirDiffUI_headerTextFunc = 'ZF_DirDiff_headerText'
 endif

--- a/plugin/ZFVimDirDiffCore.vim
+++ b/plugin/ZFVimDirDiffCore.vim
@@ -235,7 +235,13 @@ function! ZF_DirDiffPathFormat(path, ...)
     let path = a:path
     let path = fnamemodify(path, ':p')
     if !empty(get(a:, 1, ''))
-        let path = fnamemodify(path, a:1)
+        let mod_path = fnamemodify(path, a:1)
+        if get(a:, 1, '') == ':.' && path != mod_path
+            " If relative path under cwd, then prefix with . to show it's
+            " relative.
+            let mod_path = './'.. mod_path
+        endif
+        let path = mod_path
     endif
     let path = substitute(path, '\\$\|/$', '', '')
     return substitute(path, '\\', '/', 'g')


### PR DESCRIPTION
Ensures that when they're displayed in the header, they look relative --
especially if the cwd is one of the diff'd paths.

We add a ./ but if cwd is the input path, mod_path is empty and the end
result is ".". In the header, this becomes "./" as desired.

Also included minor documentation fix.