### PR TITLE
Add ZFDirMark: mark directories for diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ if you like my work, [check here](https://github.com/ZSaberLv0?utf8=%E2%9C%93&ta
     :call ZF_DirDiff("path A", "path B")
     ```
 
+1. use `:ZFDirMark` to mark two directories to start diff
+
+    Open a file and `:ZFDirMark` and the containing directory will be stored as
+    a diff candidate. Then repeat with another file and you'll be asked to
+    diff the two.
+
+    ```
+    :edit pathA/file.vim
+    :ZFDirMark
+    :edit pathB/file.vim
+    :ZFDirMark
+    ```
+
+    Or integrate with your file manager. For vim-dirvish, add
+    ~/.vim/ftplugin/dirvish.vim:
+
+        nnoremap <buffer> X :<C-u>ZFDirMark <C-r><C-l><CR>
+
+    Or for netrw, add ~/.vim/ftplugin/netrw.vim:
+
+        nnoremap <buffer> X :<C-u>ZFDirMark <C-r>=b:netrw_curdir<CR>/<C-r><C-l><CR>
+
+    Then X on two directories.
+
 1. you may also use it as command line diff tool
 
     ```

--- a/plugin/ZFVimDirMark.vim
+++ b/plugin/ZFVimDirMark.vim
@@ -1,0 +1,59 @@
+
+" ============================================================
+function! s:Mark(...) abort
+    if len(a:000) > 0
+        " Accept input path
+        let path = a:1
+    else
+        " Or current file's path
+        let path = expand('%')
+    endif
+    if !isdirectory(path)
+        let path = fnamemodify(path, ':h')
+    endif
+    let path = ZF_DirDiffPathFormat(path, ':~')
+    
+    if exists("s:dir_marked_for_diff") && s:dir_marked_for_diff != path
+        let choice = s:PromptForDiff(s:dir_marked_for_diff, path)
+        if choice == 'y'
+            call ZF_DirDiff(s:dir_marked_for_diff, path)
+            " Launched diff, so forget about mark.
+            unlet s:dir_marked_for_diff
+        else
+            call s:MarkAndPrint(path, "\n[ZFDirDiff] Instead marked %s for diff")
+        endif
+    else
+        call s:MarkAndPrint(path, "[ZFDirDiff] Marked %s for diff")
+    endif
+endfunction
+
+function! s:PromptForDiff(left, right) abort
+    echo "Diff directories:\n  ".. a:left .."\n  ".. a:right .."\n\n"
+    echo "\n"
+    echo '  (y)es'
+    echo '  (n)o'
+    echo "\n"
+    echo 'choose: '
+
+    let choice = getchar()
+    if 0
+    elseif choice == char2nr('y') || choice == char2nr('Y')
+        return 'y'
+    elseif choice == char2nr('n') || choice == char2nr('N')
+        return 'n'
+    else
+        return 'n'
+    endif
+endfunction
+
+function! s:MarkAndPrint(path, msg)
+    let s:dir_marked_for_diff = a:path
+    let shortname = s:dir_marked_for_diff
+    if len(a:msg) + len(shortname) > &columns
+        " Try to avoid "Press ENTER to continue"
+        let shortname = pathshorten(shortname)
+    endif
+    echo printf(a:msg, shortname)
+endfunction
+
+command! -nargs=? -complete=file ZFDirMark :call s:Mark(<f-args>)


### PR DESCRIPTION
Make it easier to select directories for diff. Open a file and
:ZFDirMark and it will be stored as a potential diff. Then repeat with
another file and you'll be asked to diff.

You can also pass the directory you want to diff to the command to ease
integration into file managers. Examples for dirvish and netrw are
included in the documentation.

I tried to follow your style including using getchar() instead of inputdialog().