### PR TITLE
Add visual mapping for sync and delete

### DIFF
--- a/plugin/ZFVimDirDiff.vim
+++ b/plugin/ZFVimDirDiff.vim
@@ -578,19 +578,23 @@ function! ZF_DirDiffFoldLevelUpdate(...)
 endfunction
 
 function! ZF_DirDiffSyncToHere()
-    let dataUI = s:getDataUIUnderCursor()
-    if empty(dataUI)
+    let all_data = s:getDataUIForLineRange(a:firstline, a:lastline)
+    if empty(all_data)
         return
     endif
-    call ZF_DirDiffSync(t:ZFDirDiff_fileLeft, t:ZFDirDiff_fileRight, dataUI.data.path, dataUI.data, b:ZFDirDiff_isLeft ? 'r2l' : 'l2r', 0)
+    for dataUI in all_data
+        call ZF_DirDiffSync(t:ZFDirDiff_fileLeft, t:ZFDirDiff_fileRight, dataUI.data.path, dataUI.data, b:ZFDirDiff_isLeft ? 'r2l' : 'l2r', 0)
+    endfor
     call ZF_DirDiffUpdate()
 endfunction
 function! ZF_DirDiffSyncToThere()
-    let dataUI = s:getDataUIUnderCursor()
-    if empty(dataUI)
+    let all_data = s:getDataUIForLineRange(a:firstline, a:lastline)
+    if empty(all_data)
         return
     endif
-    call ZF_DirDiffSync(t:ZFDirDiff_fileLeft, t:ZFDirDiff_fileRight, dataUI.data.path, dataUI.data, b:ZFDirDiff_isLeft ? 'l2r' : 'r2l', 0)
+    for dataUI in all_data
+        call ZF_DirDiffSync(t:ZFDirDiff_fileLeft, t:ZFDirDiff_fileRight, dataUI.data.path, dataUI.data, b:ZFDirDiff_isLeft ? 'l2r' : 'r2l', 0)
+    endfor
     call ZF_DirDiffUpdate()
 endfunction
 
@@ -954,9 +958,11 @@ function! s:setupDiffBuffer_keymap()
     endfor
     for k in g:ZFDirDiffKeymap_syncToHere
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToHere()<cr>'
+        execute 'vnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToHere()<cr>'
     endfor
     for k in g:ZFDirDiffKeymap_syncToThere
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToThere()<cr>'
+        execute 'vnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToThere()<cr>'
     endfor
     for k in g:ZFDirDiffKeymap_deleteFile
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffDeleteFile()<cr>'

--- a/plugin/ZFVimDirDiff.vim
+++ b/plugin/ZFVimDirDiff.vim
@@ -577,7 +577,7 @@ function! ZF_DirDiffFoldLevelUpdate(...)
     call s:setupDiffDataUIVisible()
 endfunction
 
-function! ZF_DirDiffSyncToHere()
+function! ZF_DirDiffSyncToHere() range
     let all_data = s:getDataUIForLineRange(a:firstline, a:lastline)
     if empty(all_data)
         return
@@ -587,7 +587,7 @@ function! ZF_DirDiffSyncToHere()
     endfor
     call ZF_DirDiffUpdate()
 endfunction
-function! ZF_DirDiffSyncToThere()
+function! ZF_DirDiffSyncToThere() range
     let all_data = s:getDataUIForLineRange(a:firstline, a:lastline)
     if empty(all_data)
         return
@@ -958,15 +958,15 @@ function! s:setupDiffBuffer_keymap()
     endfor
     for k in g:ZFDirDiffKeymap_syncToHere
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToHere()<cr>'
-        execute 'vnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToHere()<cr>'
+        execute 'xnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToHere()<cr>'
     endfor
     for k in g:ZFDirDiffKeymap_syncToThere
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToThere()<cr>'
-        execute 'vnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToThere()<cr>'
+        execute 'xnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffSyncToThere()<cr>'
     endfor
     for k in g:ZFDirDiffKeymap_deleteFile
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffDeleteFile()<cr>'
-        execute 'vnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffDeleteFile()<cr>'
+        execute 'xnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffDeleteFile()<cr>'
     endfor
     for k in g:ZFDirDiffKeymap_getPath
         execute 'nnoremap <buffer><silent> ' . k . ' :call ZF_DirDiffGetPath()<cr>'


### PR DESCRIPTION
I often try to select multiple lines to sync from one file to another (just like I would in a file diff), but zfdirdiff doesn't support that. These commits add support for sync operations (fromhere and tothere) and delete.