### PR TITLE
Create directories before cpfile

### DIFF
--- a/plugin/ZFVimDirDiffSync.vim
+++ b/plugin/ZFVimDirDiffSync.vim
@@ -9,6 +9,7 @@ function! ZF_DirDiff_mkdir(path)
 endfunction
 
 function! ZF_DirDiff_cpfile(from, to)
+    call ZF_DirDiff_mkdir(fnamemodify(a:to, ":h"))
     if has('unix')
         silent execute '!cp -rf "' . a:from . '" "' . a:to . '"'
     elseif has('win32')


### PR DESCRIPTION
Fix nothing happens when you sync a file where the parent directory only
exists on one side.

Most likely, the user wanted all the directories created, so create
them.