### PR TITLE
Force input directories to absolute paths

### DIFF
--- a/plugin/ZFVimDirDiff.vim
+++ b/plugin/ZFVimDirDiff.vim
@@ -248,11 +248,13 @@ command! -nargs=+ -complete=file ZFDirDiff :call ZF_DirDiff(<f-args>)
 
 " ============================================================
 function! ZF_DirDiff(fileLeft, fileRight)
-    let diffResult = ZF_DirDiffCore(a:fileLeft, a:fileRight)
+    let fileLeft = fnamemodify(a:fileLeft, ':p')
+    let fileRight = fnamemodify(a:fileRight, ':p')
+    let diffResult = ZF_DirDiffCore(fileLeft, fileRight)
     if diffResult['exitCode'] == g:ZFDirDiff_exitCode_BothFile
-        call s:diffByFile(a:fileLeft, a:fileRight)
+        call s:diffByFile(fileLeft, fileRight)
     else
-        call s:ZF_DirDiff_UI(a:fileLeft, a:fileRight, diffResult)
+        call s:ZF_DirDiff_UI(fileLeft, fileRight, diffResult)
     endif
     echo diffResult['exitHint']
     return diffResult


### PR DESCRIPTION
Fix failure to refresh if cwd changes when diffing relative paths.

Ensure we're tracking absolute paths so if cwd changes, we don't lose
the correct path.

This looks like a lot of change, but it's just removing the a: and
adding the two fnamemodify lines.

Test Case
    :cd ~/.vim/bundle/zfdirdiff/
    :ZFDirDiff ./ ../test/
    :cd /
    :norm DD

(DD is the default update mapping.)