### PR TITLE
Use mkdir() if available

### DIFF
--- a/plugin/api.vim
+++ b/plugin/api.vim
@@ -732,7 +732,9 @@ endfunction
 " ============================================================
 if !exists('*ZFDirDiffAPI_mkdir')
     function! ZFDirDiffAPI_mkdir(path)
-        if (has('win32') || has('win64')) && !has('unix')
+        if exists("*mkdir")
+            call mkdir(a:path, 'p')
+        elseif (has('win32') || has('win64')) && !has('unix')
             silent execute '!mkdir "' . substitute(a:path, '/', '\', 'g') . '"'
         else
             silent execute '!mkdir -p "' . a:path . '"'


### PR DESCRIPTION
Vim has a mkdir function builtin, so prefer that if available.

Test
```
:cd ~/.vim/bundle/zfdirdiff/test
:ZFDirDiff left right
:/b.txt
:normal dp
```