### PR TITLE
wrapper buffer prefix in customizable function

### DIFF
--- a/plugin/op.vim
+++ b/plugin/op.vim
@@ -48,11 +48,11 @@ if !exists('*ZFDirDiffOp_confirmHeader')
         let text = []
         call add(text, '----------------------------------------')
         if a:op != 'dr'
-            call add(text, '[LEFT] : ' . a:diffNode['name'])
+            call add(text, ZFDirDiffUI_bufLabel(v:true) . ': ' . a:diffNode['name'])
             call add(text, '    ' . ZFDirDiffAPI_pathHint(a:taskData['pathL'] . a:parentPath . a:diffNode['name'], ':~'))
         endif
         if a:op != 'dl'
-            call add(text, '[RIGHT]: ' . a:diffNode['name'])
+            call add(text, ZFDirDiffUI_bufLabel(v:false) . ': ' . a:diffNode['name'])
             call add(text, '    ' . ZFDirDiffAPI_pathHint(a:taskData['pathR'] . a:parentPath . a:diffNode['name'], ':~'))
         endif
         call add(text, '----------------------------------------')
@@ -147,16 +147,16 @@ function! s:opDelete(taskData, parentPath, diffNode, op, option)
     if a:option['confirm'] != 'a' && needConfirm
         if isLeft
             if isDir
-                let hint = 'confirm DELETE?  ' . '[LEFT(dir)] <= [RIGHT(___)]'
+                let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(dir) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             else
-                let hint = 'confirm DELETE?  ' . '[LEFT(file)] <= [RIGHT(___)]'
+                let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(file) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             endif
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
         else
             if isDir
-                let hint = 'confirm DELETE?  ' . '[LEFT(___)] => [RIGHT(dir)]'
+                let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) => ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)'
             else
-                let hint = 'confirm DELETE?  ' . '[LEFT(___)] => [RIGHT(file)]'
+                let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) => ' . ZFDirDiffUI_bufLabel(v:false) . '(file)'
             endif
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
         endif
@@ -240,7 +240,7 @@ endfunction
 " ============================================================
 function! s:op_T_DIR(taskData, parentPath, diffNode, op, option)
     if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmSyncDir', 1)
-        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? '[LEFT(dir)] => [RIGHT(dir)]' : '[LEFT(dir)] <= [RIGHT(dir)]')
+        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? ZFDirDiffUI_bufLabel(v:true) . '(dir) => ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)' : ZFDirDiffUI_bufLabel(v:true) . '(dir) <= [RIGHT(dir)]')
         let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
         if choice == 'n' || choice == 'q' | return choice | endif
     endif
@@ -252,7 +252,7 @@ function! s:op_T_SAME(taskData, parentPath, diffNode, op, option)
         return a:option['confirm']
     endif
     if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmSyncFile', 1)
-        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? '[LEFT(file)] => [RIGHT(file)]' : '[LEFT(file)] <= [RIGHT(file)]')
+        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? ZFDirDiffUI_bufLabel(v:true) . '(file) => '. ZFDirDiffUI_bufLabel(v:false) . '(file)' : ZFDirDiffUI_bufLabel(v:true) . '(file) <= [RIGHT(file)]')
         let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
         if choice == 'n' || choice == 'q' | return choice | endif
     endif
@@ -261,7 +261,7 @@ endfunction
 
 function! s:op_T_DIFF(taskData, parentPath, diffNode, op, option)
     if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmSyncFile', 1)
-        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? '[LEFT(file)] => [RIGHT(file)]' : '[LEFT(file)] <= [RIGHT(file)]')
+        let hint = 'confirm sync?  ' . (a:op == 'l2r' ? ZFDirDiffUI_bufLabel(v:true) . '(file) => ' . ZFDirDiffUI_bufLabel(v:false) . '(file)' : ZFDirDiffUI_bufLabel(v:true) . '(file) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(file)')
         let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
         if choice == 'n' || choice == 'q' | return choice | endif
     endif
@@ -271,14 +271,14 @@ endfunction
 function! s:op_T_DIR_LEFT(taskData, parentPath, diffNode, op, option)
     if a:op == 'l2r'
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmCopyDir', 1)
-            let hint = 'confirm copy?  ' . '[LEFT(dir)] => [RIGHT(___)]'
+            let hint = 'confirm copy?  ' . ZFDirDiffUI_bufLabel(v:true) . '(dir) => ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
         return s:opCopyDir(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteDir', 1)
-            let hint = 'confirm DELETE?  ' . '[LEFT(dir)] <= [RIGHT(___)]'
+            let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(dir) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -289,14 +289,14 @@ endfunction
 function! s:op_T_DIR_RIGHT(taskData, parentPath, diffNode, op, option)
     if !(a:op == 'l2r')
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmCopyDir', 1)
-            let hint = 'confirm copy?  ' . '[LEFT(___)] <= [RIGHT(dir)]'
+            let hint = 'confirm copy?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
         return s:opCopyDir(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteDir', 1)
-            let hint = 'confirm DELETE?  ' . '[LEFT(___)] => [RIGHT(dir)]'
+            let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) => ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -307,14 +307,14 @@ endfunction
 function! s:op_T_FILE_LEFT(taskData, parentPath, diffNode, op, option)
     if a:op == 'l2r'
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmCopyFile', 0)
-            let hint = 'confirm copy?  ' . '[LEFT(file)] => [RIGHT(___)]'
+            let hint = 'confirm copy?  ' . ZFDirDiffUI_bufLabel(v:true) . '(file) => ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
         return s:opCopyFile(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteFile', 1)
-            let hint = 'confirm DELETE?  ' . '[LEFT(file)] <= [RIGHT(___)]'
+            let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(file) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(___)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -325,14 +325,14 @@ endfunction
 function! s:op_T_FILE_RIGHT(taskData, parentPath, diffNode, op, option)
     if !(a:op == 'l2r')
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmCopyFile', 0)
-            let hint = 'confirm copy?  ' . '[LEFT(___)] <= [RIGHT(file)]'
+            let hint = 'confirm copy?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(file)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
         return s:opCopyFile(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteFile', 1)
-            let hint = 'confirm DELETE?  ' . '[LEFT(___)] => [RIGHT(file)]'
+            let hint = 'confirm DELETE?  ' . ZFDirDiffUI_bufLabel(v:true) . '(___) => ' . ZFDirDiffUI_bufLabel(v:false) . '(file)'
             let choice = s:opConfirm(hint, '', a:fileRight . '/' . a:path, 'dr')
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -343,7 +343,7 @@ endfunction
 function! s:op_T_CONFLICT_DIR_LEFT(taskData, parentPath, diffNode, op, option)
     if a:op == 'l2r'
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteFile', 1)
-            let hint = 'confirm sync CONFLICT?  ' . '[LEFT(dir)] => [RIGHT(file)]'
+            let hint = 'confirm sync CONFLICT?  ' . ZFDirDiffUI_bufLabel(v:true) . '(dir) => ' . ZFDirDiffUI_bufLabel(v:false) . '(file)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -351,7 +351,7 @@ function! s:op_T_CONFLICT_DIR_LEFT(taskData, parentPath, diffNode, op, option)
         return s:opCopyDir(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteDir', 1)
-            let hint = 'confirm sync CONFLICT?  ' . '[LEFT(dir)] <= [RIGHT(file)]'
+            let hint = 'confirm sync CONFLICT?  ' . ZFDirDiffUI_bufLabel(v:true) . '(dir) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(file)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -363,7 +363,7 @@ endfunction
 function! s:op_T_CONFLICT_DIR_RIGHT(taskData, parentPath, diffNode, op, option)
     if !(a:op == 'l2r')
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteFile', 1)
-            let hint = 'confirm sync CONFLICT?  ' . '[LEFT(file)] <= [RIGHT(dir)]'
+            let hint = 'confirm sync CONFLICT?  ' . ZFDirDiffUI_bufLabel(v:true) . '(file) <= ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif
@@ -371,7 +371,7 @@ function! s:op_T_CONFLICT_DIR_RIGHT(taskData, parentPath, diffNode, op, option)
         return s:opCopyDir(a:taskData, a:parentPath, a:diffNode, a:op, a:option)
     else
         if a:option['confirm'] != 'a' && get(g:, 'ZFDirDiffUI_confirmDeleteDir', 1)
-            let hint = 'confirm sync CONFLICT?  ' . '[LEFT(file)] => [RIGHT(dir)]'
+            let hint = 'confirm sync CONFLICT?  ' . ZFDirDiffUI_bufLabel(v:true) . '(file) => ' . ZFDirDiffUI_bufLabel(v:false) . '(dir)'
             let choice = s:opConfirm(hint, a:taskData, a:parentPath, a:diffNode, a:op, a:option)
             if choice == 'n' || choice == 'q' | return choice | endif
         endif

--- a/plugin/ui.vim
+++ b/plugin/ui.vim
@@ -38,13 +38,13 @@ endfunction
 if !exists('*ZFDirDiffUI_cbHeader')
     function! ZFDirDiffUI_cbHeader(taskData)
         let headerL = [
-                    \   '[LEFT]: ' . ZFDirDiffAPI_pathHint(a:taskData['pathL'], ':~'),
-                    \   '[LEFT]: ' . ZFDirDiffAPI_pathHint(a:taskData['pathL'], ':.'),
+                    \   ZFDirDiffUI_bufLabel(v:true) . ': ' . ZFDirDiffAPI_pathHint(a:taskData['pathL'], ':~'),
+                    \   ZFDirDiffUI_bufLabel(v:true) . ': ' . ZFDirDiffAPI_pathHint(a:taskData['pathL'], ':.'),
                     \   '------------------------------------------------------------',
                     \ ]
         let headerR = [
-                    \   '[RIGHT]: ' . ZFDirDiffAPI_pathHint(a:taskData['pathR'], ':~'),
-                    \   '[RIGHT]: ' . ZFDirDiffAPI_pathHint(a:taskData['pathR'], ':.'),
+                    \   ZFDirDiffUI_bufLabel(v:false) . ': ' . ZFDirDiffAPI_pathHint(a:taskData['pathR'], ':~'),
+                    \   ZFDirDiffUI_bufLabel(v:false) . ': ' . ZFDirDiffAPI_pathHint(a:taskData['pathR'], ':.'),
                     \   '------------------------------------------------------------',
                     \ ]
         return {
@@ -82,7 +82,7 @@ if !exists('*ZFDirDiffUI_statusline')
         if !exists('t:ZFDirDiff_taskData')
             return ''
         endif
-        return '[' . (a:isLeft ? 'LEFT' : 'RIGHT') . ']: '
+        return ZFDirDiffUI_bufLabel(a:isLeft) . ': '
                     \ . substitute(t:ZFDirDiff_taskData[a:isLeft ? 'fileL' : 'fileR'], '%', '%%', 'g')
                     \ . '%=%k %3p%%'
     endfunction
@@ -95,7 +95,7 @@ if !exists('*ZFDirDiffUI_confirmHeader')
         if !empty(a:pathL)
             let path = ZFDirDiffAPI_pathHint(a:pathL, ':t')
             let relpath = ZFDirDiffAPI_pathHint(a:pathL, ':~')
-            call add(text, '[LEFT] : ' . path)
+            call add(text, ZFDirDiffUI_bufLabel(v:true) . ': ' . path)
             if path != relpath
                 call add(text, '    ' . relpath)
             endif
@@ -103,7 +103,7 @@ if !exists('*ZFDirDiffUI_confirmHeader')
         if !empty(a:pathR)
             let path = ZFDirDiffAPI_pathHint(a:pathR, ':t')
             let relpath = ZFDirDiffAPI_pathHint(a:pathR, ':~')
-            call add(text, '[RIGHT]: ' . path)
+            call add(text, ZFDirDiffUI_bufLabel(v:false) . ': ' . path)
             if path != relpath
                 call add(text, '    ' . relpath)
             endif
@@ -306,6 +306,12 @@ function! s:diffUI_create(reuseTab)
     call s:diffUI_bufSetup(0)
 endfunction
 
+if !exists('*ZFDirDiffUI_bufLabel')
+    function! ZFDirDiffUI_bufLabel(isLeft)
+        return a:isLeft ? '[LEFT]': '[RIGHT]'
+    endfunction
+endif
+
 function! s:diffUI_bufSetup(isLeft)
     call s:diffUI_makeKeymap()
     execute 'set filetype=' . get(g:, 'ZFDirDiffUI_filetype', 'ZFDirDiff')
@@ -317,11 +323,7 @@ function! s:diffUI_bufSetup(isLeft)
     setlocal buflisted
     setlocal nowrap
     setlocal noswapfile
-    if a:isLeft
-        execute 'silent! file [LEFT] ' . bufnr()
-    else
-        execute 'silent! file [RIGHT] ' . bufnr()
-    endif
+    execute 'silent! file ' . ZFDirDiffUI_bufLabel(a:isLeft) . ' ' . bufnr()
     setlocal nomodified
     setlocal nomodifiable
     set scrollbind
@@ -928,7 +930,7 @@ function! ZFDirDiffUIAction_markToDiff()
                     \ }
         call ZFDirDiffHLImpl_dataChanged(t:ZFDirDiff_taskData, bufnr)
         echo '[ZFDirDiff] mark again to diff with: '
-                    \ . (isLeft ? '[LEFT]' : '[RIGHT]')
+                    \ . ZFDirDiffUI_bufLabel(a:isLeft)
                     \ . parentPath . diffNode['name']
         return
     endif


### PR DESCRIPTION
I extract all the possible prefixes and wrap into a customizable function.

But looking into usages, maybe `_bufLabel` is not the best text for this fuction.

This is just a starter to see best way to mark this buffers, probably just `[L]` or `[R]`.

Probably more functions can generalize this and allow easily to i18n

relates #35