### PR TITLE
Updated ZFDirDiff.sh to work with both absolute and relative paths.

### DIFF
--- a/ZFDirDiff.sh
+++ b/ZFDirDiff.sh
@@ -1,6 +1,19 @@
 WORK_DIR=$(cd "$(dirname "$0")"; pwd)
-PATH_A=$1
-PATH_B=$2
+
+# Check if absolute path is given for PATH_A
+if [[ "$1" = /* ]]; then
+    PATH_A=$1
+else
+    PATH_A=$(pwd)/$1
+fi
+
+# Check if absolute path is given for PATH_B
+if [[ "$2" = /* ]]; then
+    PATH_B=$2
+else
+    PATH_B=$(pwd)/$2
+fi
+
 if test "0" = "1" \
     || test "x-$PATH_A" = "x-" \
     || test "x-$PATH_B" = "x-" \
@@ -15,4 +28,3 @@ if test "x-$ZFDIRDIFF_VIM" = "x-"; then
 fi
 
 "$ZFDIRDIFF_VIM" -c "call ZFDirDiff(\"$PATH_A\", \"$PATH_B\")"
-


### PR DESCRIPTION
The current version of ZFDirDiff.sh fails if a relative path is provided. 
This fix works for both absolute and relative paths. 